### PR TITLE
fix: Remove duplicate "descriptor" property access

### DIFF
--- a/lib/service/interface.js
+++ b/lib/service/interface.js
@@ -155,7 +155,7 @@ function method (options) {
   return function (descriptor) {
     options.name = options.name || descriptor.key;
     assertMemberNameValid(options.name);
-    options.fn = descriptor.descriptor.value;
+    options.fn = descriptor.value;
     descriptor.finisher = function (klass) {
       klass.prototype.$methods = klass.prototype.$methods || [];
       klass.prototype.$methods[descriptor.key] = options;


### PR DESCRIPTION
I'm using Typescript 5.2.2 to compile the decorators to JS.

When running the code with Node.js v18.17.1 I got this exception:

```
 /app/node_modules/reflect-metadata/Reflect.js:553
                var decorated = decorator(target, propertyKey, descriptor);
                                ^
TypeError: Cannot read properties of undefined (reading 'value')
    at /app/node_modules/dbus-final/lib/service/interface.js:158:40
    at DecorateProperty (/app/node_modules/reflect-metadata/Reflect.js:553:33)
    at Reflect.decorate (/app/node_modules/reflect-metadata/Reflect.js:123:24)
```

The `@method` decorator  in dbus-final/lib/service/interface.js has this in line 158
 `options.fn = descriptor.descriptor.value;`

This seems like a typo as `descriptor` has no child [property `descriptor` but only the value.](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyDescriptor#description)


Removing the seconds `.descriptor` fixed the issue for me.